### PR TITLE
Chapter08: ワークフローの実行完了待機と自動承認の設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
                                       # NOTE: GitHub Actions の場合は / 固定
     schedule:                         # バージョンアップスケジュール
       interval: daily
+    ignore:                                       # バージョンアップの除外設定
+      - dependency-name: actions/upload-artifact  # 除外する依存関係の名前
+        versions:                                 # 除外対象のバージョン
+          - 4.3.0
+          - 4.3.1
+      - dependency-name: 'actions/*'              # アスタリスクは任意文字列にマッチ
+        update-types:                             # 除外するバージョンアップの種類
+          - version-update:semver-major           # メジャーバージョンアップは除外

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,4 +12,4 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # GITHUB CLIのクレデンシャル
     steps:
       - uses: actions/checkout@v4
-      - run: gh pr merge "${GITHUB_HEAD_REF}" --merge   # GITHUB CLIでマージ
+      - run: gh pr merge "${GITHUB_HEAD_REF}" --merge --auto  # GITHUB CLIでマージ

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+name: Auto merge
+run-name: Auto merge pull request
+on: pull_request
+jobs:
+  auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}  # Dependabotのプルリクエストのみ
+    runs-on: ubuntu-latest
+    permissions:                                  # マージに必要なパーミッション
+      contents: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # GITHUB CLIのクレデンシャル
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh pr merge "${GITHUB_HEAD_REF}" --merge   # GITHUB CLIでマージ

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,4 +12,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # GITHUB CLIのクレデンシャル
     steps:
       - uses: actions/checkout@v4
-      - run: gh pr merge "${GITHUB_HEAD_REF}" --merge --auto  # GITHUB CLIでマージ
+      - run: |
+          gh pr review "${GITHUB_HEAD_REF}" --approve       # GITHUB CLIでプルリクエストを自動承認
+          gh pr merge "${GITHUB_HEAD_REF}" --merge --auto   # GITHUB CLIでマージ

--- a/.github/workflows/old-version-go.yml
+++ b/.github/workflows/old-version-go.yml
@@ -5,4 +5,4 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5 # 古いバージョンを意図的に指定
+      - uses: actions/setup-go@v4 # 古いバージョンを意図的に指定


### PR DESCRIPTION
* ワークフローの実行は、Dependabotが作成したプルリクエストに制限する
* マージは、`GITHUB CLI` のコマンド実行により行う（`gh pr merge ... --merge`）
  * 上記は https://github.com/ytak-sagit/hands-on-github-cicd/pull/7 にて実装
* 全ワークフローの実行完了後に自動マージされるように設定（`gh pr merge ... --merge --auto`）
* Dependabotが作成したプルリクエストは、承認を必須にしない（自動承認する）ように設定
  * `gh pr review ... --approve`
