### PR TITLE
fix: `groupadd`コマンドが実行できないため、直接`UID`を指定する形に修正

### DIFF
--- a/docker/example/Dockerfile
+++ b/docker/example/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.25-alpine
 # Add: Trivy で検出された AVD-DS-0002 脆弱性への対応 ->
-RUN groupadd -r workgroup && useradd --no-log-init -r -g workgroup workuser
-USER workuser
+# NOTE: 101 = nginx の User Id
+ARG UID=101
+USER $UID
 # Add: Trivy で検出された AVD-DS-0002 脆弱性への対応 <-
 RUN echo 'Hello GitHub Packages' > /usr/share/nginx/html/index.html


### PR DESCRIPTION
https://github.com/ytak-sagit/hands-on-github-cicd/actions/runs/10019445264 がエラーとなったため、その対処